### PR TITLE
fix: select explicitly `password` so that it can be compared with input

### DIFF
--- a/src/modules/Crypt.ts
+++ b/src/modules/Crypt.ts
@@ -9,9 +9,9 @@ export default class Crypt {
     hash,
   }) {
     return new Promise((resolve, reject) => {
-      bcrypt.compare(src, hash, (err, hash) => {
-        if (err) resolve(false);
-        resolve(true);
+      bcrypt.compare(src, hash, (err, res: boolean) => {
+        err && resolve(false);
+        resolve(res);
       });
     });
   }

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -22,6 +22,7 @@ export default class UserSignInService {
     try {
       const userRepo = getCustomRepository(UserRepository, DB1);
       const user = (await userRepo.find({
+        select: [ 'username', 'password' ],
         where: {
           email: param.email,
         },


### PR DESCRIPTION
Fixes https://github.com/marmoym/marmoym/issues/81

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
